### PR TITLE
Refine airtime budgeting and packet prioritization

### DIFF
--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -65,7 +65,11 @@ void Dispatcher::loop() {
       //Serial.print("  airtime="); Serial.println(t);
 
       // will need radio silence up to next_tx_time
-      next_tx_time = futureMillis(t * getAirtimeBudgetFactor());
+      if (outbound && outbound->isControlPayload()) {
+        next_tx_time = futureMillis(t * getControlAirtimeBudgetFactor());
+      } else {
+        next_tx_time = futureMillis(t * getDataAirtimeBudgetFactor());
+      }
 
       _radio->onSendFinished();
       logTx(outbound, 2 + outbound->path_len + outbound->payload_len);

--- a/src/Dispatcher.h
+++ b/src/Dispatcher.h
@@ -154,6 +154,8 @@ protected:
   virtual const char* getLogDateTime() { return ""; }
 
   virtual float getAirtimeBudgetFactor() const;
+  virtual float getControlAirtimeBudgetFactor() const { return 1.0f; }
+  virtual float getDataAirtimeBudgetFactor() const { return 2.0f; }
   virtual int calcRxDelay(float score, uint32_t air_time) const;
   virtual uint32_t getCADFailRetryDelay() const;
   virtual uint32_t getCADFailMaxDuration() const;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -599,14 +599,7 @@ void Mesh::sendFlood(Packet* packet, uint32_t delay_millis) {
 
   _tables->hasSeen(packet); // mark this packet as already sent in case it is rebroadcast back to us
 
-  uint8_t pri;
-  if (packet->getPayloadType() == PAYLOAD_TYPE_PATH) {
-    pri = 2;
-  } else if (packet->getPayloadType() == PAYLOAD_TYPE_ADVERT) {
-    pri = 3;   // de-prioritie these
-  } else {
-    pri = 1;
-  }
+  uint8_t pri = getPriorityFor(packet);
   sendPacket(packet, pri, delay_millis);
 }
 
@@ -624,11 +617,7 @@ void Mesh::sendDirect(Packet* packet, const uint8_t* path, uint8_t path_len, uin
     pri = 5;   // maybe make this configurable
   } else {
     memcpy(packet->path, path, packet->path_len = path_len);
-    if (packet->getPayloadType() == PAYLOAD_TYPE_PATH) {
-      pri = 1;   // slightly less priority
-    } else {
-      pri = 0;
-    }
+    pri = getPriorityFor(packet);
   }
   _tables->hasSeen(packet); // mark this packet as already sent in case it is rebroadcast back to us
   sendPacket(packet, pri, delay_millis);
@@ -642,7 +631,7 @@ void Mesh::sendZeroHop(Packet* packet, uint32_t delay_millis) {
 
   _tables->hasSeen(packet); // mark this packet as already sent in case it is rebroadcast back to us
 
-  sendPacket(packet, 0, delay_millis);
+  sendPacket(packet, getPriorityFor(packet), delay_millis);
 }
 
 }

--- a/src/Packet.h
+++ b/src/Packet.h
@@ -75,6 +75,11 @@ public:
    */
   uint8_t getPayloadVer() const { return (header >> PH_VER_SHIFT) & PH_VER_MASK; }
 
+  bool isControlPayload() const {
+    uint8_t t = getPayloadType();
+    return t == PAYLOAD_TYPE_ACK || t == PAYLOAD_TYPE_ADVERT || t == PAYLOAD_TYPE_PATH;
+  }
+
   void markDoNotRetransmit() { header = 0xFF; }
   bool isMarkedDoNotRetransmit() const { return header == 0xFF; }
 


### PR DESCRIPTION
Introduces separate airtime budget factors for control and data packets in Dispatcher, and refactors Mesh to use a centralized getPriorityFor() method for packet prioritization.