### PR TITLE
fix(kiss_modem): improve RX delivery and noise floor sampling

### DIFF
--- a/examples/kiss_modem/KissModem.cpp
+++ b/examples/kiss_modem/KissModem.cpp
@@ -99,6 +99,11 @@ void KissModem::loop() {
 
     if (_rx_len < KISS_MAX_FRAME_SIZE) {
       _rx_buf[_rx_len++] = b;
+    } else {
+      /* Buffer full with no FEND; reset so we don't stay stuck ignoring input. */
+      _rx_len = 0;
+      _rx_escaped = false;
+      _rx_active = false;
     }
   }
 

--- a/examples/kiss_modem/KissModem.h
+++ b/examples/kiss_modem/KissModem.h
@@ -197,4 +197,6 @@ public:
 
   void onPacketReceived(int8_t snr, int8_t rssi, const uint8_t* packet, uint16_t len);
   bool isTxBusy() const { return _tx_state != TX_IDLE; }
+  /** True only when radio is actually transmitting; use to skip recvRaw in main loop. */
+  bool isActuallyTransmitting() const { return _tx_state == TX_SENDING; }
 };

--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -112,16 +112,12 @@ void setup() {
 void loop() {
   modem->loop();
 
-  if ((uint32_t)(millis() - next_noise_floor_calib_ms) >= NOISE_FLOOR_CALIB_INTERVAL_MS) {
-    radio_driver.triggerNoiseFloorCalibrate(0);
-    next_noise_floor_calib_ms = millis();
-  }
-  radio_driver.loop();
-
-  if (!modem->isTxBusy()) {
-    if ((uint32_t)(millis() - next_agc_reset_ms) >= AGC_RESET_INTERVAL_MS) {
-      radio_driver.resetAGC();
-      next_agc_reset_ms = millis();
+  if (!modem->isActuallyTransmitting()) {
+    if (!modem->isTxBusy()) {
+      if ((uint32_t)(millis() - next_agc_reset_ms) >= AGC_RESET_INTERVAL_MS) {
+        radio_driver.resetAGC();
+        next_agc_reset_ms = millis();
+      }
     }
 
     uint8_t rx_buf[256];
@@ -130,6 +126,22 @@ void loop() {
       int8_t snr = (int8_t)(radio_driver.getLastSNR() * 4);
       int8_t rssi = (int8_t)radio_driver.getLastRSSI();
       modem->onPacketReceived(snr, rssi, rx_buf, rx_len);
+    }
+    /* Sample noise floor right after drain: we're in STATE_RX so wrapper can collect. */
+    for (int i = 0; i < 16; i++) {
+      radio_driver.loop();
+    }
+  }
+
+  /* Trigger starts a new 64-sample calibration window every 2s. */
+  if ((uint32_t)(millis() - next_noise_floor_calib_ms) >= NOISE_FLOOR_CALIB_INTERVAL_MS) {
+    radio_driver.triggerNoiseFloorCalibrate(0);
+    next_noise_floor_calib_ms = millis();
+  }
+  radio_driver.loop();
+  if (!modem->isActuallyTransmitting()) {
+    for (int i = 0; i < 15; i++) {
+      radio_driver.loop();
     }
   }
 }

--- a/variants/rak4631/platformio.ini
+++ b/variants/rak4631/platformio.ini
@@ -184,3 +184,12 @@ build_flags =
 build_src_filter = ${rak4631.build_src_filter}
   +<helpers/ui/SSD1306Display.cpp>
   +<../examples/simple_sensor>
+
+[env:RAK_4631_kiss_modem]
+extends = rak4631
+build_flags =
+  ${rak4631.build_flags}
+build_src_filter = ${rak4631.build_src_filter}
+  +<../examples/kiss_modem/>
+lib_deps =
+  ${rak4631.lib_deps}


### PR DESCRIPTION
I updated the pyMC_core wrapper to work with the new implementation, but I would only see a few packets and then nothing. I put the radio in RX mode, no packets. When I hooked it up to pyMC_core with the wrapper, I was also getting -120 noise floor because we weren't collecting enough samples per two second window. Changes:

- RX: Only skip polling when the radio is actually transmitting (isActuallyTransmitting()), not for the whole TX state machine. During TX_WAIT_CLEAR, TX_SLOT_WAIT, and TX_DELAY the radio stays in RX; previously we didn’t call recvRaw() in those phases and could miss packets.
- Noise floor: Call recvRaw() before radio_driver.loop() so the radio is in STATE_RX when the wrapper samples (it only samples when state == STATE_RX). Run radio_driver.loop() multiple times when not transmitting so we collect the 64 samples per calibration window faster. (This is all I could think of without changing the RadioLib wrapper.)
- KISS serial RX: If the RX buffer fills without a closing FEND, reset the parser so we don’t stay stuck ignoring input.
- New API: KissModem::isActuallyTransmitting() (true only in TX_SENDING) for use in the main loop.

This together with the [pyMC kiss-modem wrapper here](https://github.com/agessaman/pyMC_core/tree/wrapper-kiss-spec-compliance) are working well.

<img width="2306" height="1392" alt="image" src="https://github.com/user-attachments/assets/ac6bdcb6-9228-40c3-8232-24bb1550a2fa" />
