### PR TITLE
Simplify kiss noise floor

### DIFF
--- a/examples/kiss_modem/main.cpp
+++ b/examples/kiss_modem/main.cpp
@@ -136,21 +136,11 @@ void loop() {
       int8_t rssi = (int8_t)radio_driver.getLastRSSI();
       modem->onPacketReceived(snr, rssi, rx_buf, rx_len);
     }
-    /* Sample noise floor right after drain: we're in STATE_RX so wrapper can collect. */
-    for (int i = 0; i < 16; i++) {
-      radio_driver.loop();
-    }
   }
 
-  /* Trigger starts a new 64-sample calibration window every 2s. */
   if ((uint32_t)(millis() - next_noise_floor_calib_ms) >= NOISE_FLOOR_CALIB_INTERVAL_MS) {
     radio_driver.triggerNoiseFloorCalibrate(0);
     next_noise_floor_calib_ms = millis();
   }
   radio_driver.loop();
-  if (!modem->isActuallyTransmitting()) {
-    for (int i = 0; i < 15; i++) {
-      radio_driver.loop();
-    }
-  }
 }


### PR DESCRIPTION
Sorry to send over another PR on this... I updated the wrapper to use the newest version of this implementation, and saw the noise floor was crashing to -120 again. Due to the simplified loop in main, everything works properly without my extra fiddling to create sufficient samples.

<img width="223" height="187" alt="image" src="https://github.com/user-attachments/assets/4956700c-c568-4efa-b0b8-7282af817f38" />
